### PR TITLE
Fix typo in MobvoiApiClient example under Data Transmission 

### DIFF
--- a/doc/wearable-api.en.md
+++ b/doc/wearable-api.en.md
@@ -21,7 +21,7 @@ MobvoiApiClient mClient = new MobvoiApiClient.Builder(this)
                 Log.d(TAG, "onConnectionSuspended: " + cause);
             }
         })
-        .addOnConnectionFailedListener(new OnCoionFailedListener() {
+        .addOnConnectionFailedListener(new OnConnectionFailedListener() {
             @Override
             public void onConnectionFailed(ConnectionResult result) {
                 Log.d(TAG, "onConnectionFailed: " + result);


### PR DESCRIPTION
method **.addOnCoionFailedListener()** currently shows it acceps "_OnCoionFailedListener_" it should be "_OnConnectionFailedListener_"